### PR TITLE
prevent users from multiSubmits

### DIFF
--- a/src/main/webapp/js/maps-page-loader.js
+++ b/src/main/webapp/js/maps-page-loader.js
@@ -138,6 +138,7 @@ function buildPopupWindowInput(cinemaName, key) {
     } else {
       window.location.href = "/login";
     }
+    this.disabled = true;
   };
 }
 


### PR DESCRIPTION
Prevents users from pressing the submit reviews button multiple times. (can only submit one review each time)